### PR TITLE
Fix the problem that lock file remains if apt-mirror die()'d

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -300,6 +300,7 @@ check_lock();
 $SIG{INT} = "unlock_aptmirror";
 $SIG{HUP} = "unlock_aptmirror";
 $SIG{TERM} = "unlock_aptmirror";
+$SIG{__DIE__} = "unlock_aptmirror";
 
 lock_aptmirror();
 


### PR DESCRIPTION
I wrote /etc/apt/sources.list like this.

> deb ftp://ftp2.jp.debian.org/debian/ stable main #contrib non-free

This caused apt-mirror GET a wrong URL and die().

> Downloading 29 index files using 20 threads...
> Begin time: Mon Mar 19 04:00:01 2012
> [20]... [19]... [18]... [17]... [16]... [15]... [14]... [13]... [12]... [11]... [10]... [9]... [8]... [7]... [6]... [5]... [4]... [3]... [2]... [1]... [0]...
> End time: Mon Mar 19 04:03:50 2012
> 
> Proceed indexes: [Ssh: cannot open ftp2.jp.debian.org/debian///dists/stable/#contrib/source/Sources.gz: No such file
> apt-mirror: can't open index in proceed_index_gz at /usr/bin/apt-mirror line 450.

Next time apt-mirror runs, it will exit quickly because a lock file exists.

NOTE: I have fixed a lock file issue. but have not fixed a comment issue.
apt-mirror might should ignore string after a comment character? (like apt-get, aptitude, and so on)
