### PR TITLE
Patch for missing i18n Index files

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -409,6 +409,7 @@ foreach (@config_binaries)
                 add_url_to_download( $url . $_ . "/i18n/Translation-" . $lang . ".gz" );
                 add_url_to_download( $url . $_ . "/i18n/Translation-" . $lang . ".bz2" );
             }
+        add_url_to_download( $url . $_ . "/i18n/Index" );
         }
     }
     else


### PR DESCRIPTION
Hi,

the Index files in i18n directories don't get synced. I modified your code to mirror the Index files too. Works for me.

Regards
Rafael
