### PR TITLE
Updated Translations

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -111,7 +111,9 @@ my %config_variables = (
     "auth_no_challenge"    => 0,
     "no_check_certificate" => 0,
     "unlink"               => 0,
-    "postmirror_script"    => '$var_path/postmirror.sh'
+    "postmirror_script"    => '$var_path/postmirror.sh',
+    "proxy_user"           => '',
+    "proxy_password"       => ''
 );
 
 my @config_binaries = ();
@@ -186,19 +188,12 @@ sub format_bytes
 sub get_variable
 {
     my $value = $config_variables{ shift @_ };
-    if (defined $value)
+    my $count = 16;
+    while ( $value =~ s/\$(\w+)/$config_variables{$1}/xg )
     {
-        my $count = 16;
-        while ( $value =~ s/\$(\w+)/$config_variables{$1}/xg )
-        {
-            die("apt-mirror: too many substitution while evaluating variable") if ( $count-- ) < 0;
-        }
-        return $value;
+        die("apt-mirror: too many substitution while evaluating variable") if ( $count-- ) < 0;
     }
-    else
-    {
-        return "";
-    }
+    return $value;
 }
 
 sub lock_aptmirror
@@ -233,7 +228,13 @@ sub download_urls
     if ( get_variable("auth_no_challenge") == 1 )    { push( @args, "--auth-no-challenge" ); }
     if ( get_variable("no_check_certificate") == 1 ) { push( @args, "--no-check-certificate" ); }
     if ( get_variable("unlink") == 1 )               { push( @args, "--unlink" ); }
-
+    if ( length ( get_variable("use_proxy") ) && ( get_variable("use_proxy") eq 'yes' || get_variable("use_proxy") eq 'on' ) )
+    {
+        if ( length ( get_variable("http_proxy") ) )        { push( @args, "-e use_proxy=yes"); push( @args, "-e http_proxy=" . get_variable( "http_proxy" ) ); }
+        if ( length ( get_variable("proxy_user") ) )        { push( @args, "-e proxy_user=" . get_variable( "proxy_user" ) ); }
+        if ( length ( get_variable("proxy_password") ) )    { push( @args, "-e proxy_password=" . get_variable( "proxy_password" ) ); }
+    }
+    
     print "Downloading " . scalar(@urls) . " $stage files using $nthreads threads...\n";
 
     while ( scalar @urls )


### PR DESCRIPTION
New translation-codes for the i18n-directory. Related to issue #9. Removed translations: ast,eo,eu,fa,ka,oc because there are no offical languages in ISO-3166-1 alpha-2.
