### PR TITLE
Do not overwrite existing mirror.list

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,13 @@ sudo chmod +x /usr/local/bin/apt-mirror;
 
 echo "Installing apt-mirror configuration ...";
 sudo mkdir -p /etc/apt/;
-sudo cp mirror.list /etc/apt/;
+if [ -f "/etc/apt/mirror.list" ]; then
+    echo "Found existing mirror.list in /etc/apt ...";
+    echo "Copy new mirror.list to /etc/apt/mirror.list.orig ...";
+    sudo cp mirror.list /etc/apt/mirror.list.orig;
+else
+    sudo cp mirror.list /etc/apt/;
+fi
 
 echo "Installing apt-mirror manual ...";
 sudo mkdir -p /usr/share/man/man1/


### PR DESCRIPTION
I think the install.sh script should not overwrite an existing mirror.list file in /etc/apt/. I've lost all my repo settings by executing the installer.sh script to update my installation :)

This pull request modifies the install.sh script to test if there is an mirror.list file in /etc/apt and then install the original to /etc/apt/mirror.list.orig.
