### PR TITLE
Allow skipping contents to suit local usage patterns

### DIFF
--- a/AdvancedMirrorConfig.list
+++ b/AdvancedMirrorConfig.list
@@ -1,0 +1,55 @@
+############# config ##################
+#
+ set base_path    /media/sunny/PartB/UbuntuRepo
+#
+ set mirror_path  $base_path/mirror
+ set skel_path    $base_path/skel
+ set var_path     $base_path/var
+# set cleanscript $var_path/clean.sh
+# set defaultarch  <running host architecture>
+# set postmirror_script $var_path/postmirror.sh
+# set run_postmirror 0
+set nthreads     20
+set _tilde 0
+skip size_more_than 10000000 reason "because it is more than 10MB"
+skip section games reason "because it is a game package"
+skip if_name_contains dbg reason "because it is a debug package"
+skip if_name_contains "linux-image" reason "because it is a kernel package"
+skip if_name_contains "linux-headers" reason "because it is a kernel package"
+skip if_name_contains "linux-backports" reason "because it is a kernel package"
+skip if_name_contains "cloud" reason "because it is a kernel package"
+skip if_name_contains "linux-generic" reason "because it is a kernel package"
+skip if_name_contains "linux-lts-trusty-tools" reason "because it is a kernel package"
+skip if_name_contains locale except if_name_contains "locale-en" except if_name_ends_with locale reason "because it is a non english locale package"
+
+exception if_name_contains git reason "because we like git"
+exception if_name_contains "3.16.0-31" reason "because we want this kernel package version 3.16.0-31"
+exception if_name_contains gcc reason "because we like gcc"
+
+#
+############# end config ##############
+
+
+deb http://ppa.launchpad.net/git-core/ppa/ubuntu precise main
+deb-i386 http://ppa.launchpad.net/git-core/ppa/ubuntu precise main
+
+deb http://www.bchemnet.com/suldr/ debian extra
+deb-i386 http://www.bchemnet.com/suldr/ debian extra
+
+## Ubuntu Precise (12.04)
+deb http://archive.ubuntu.com/ubuntu precise main restricted universe
+deb http://archive.ubuntu.com/ubuntu precise-security main restricted universe
+deb http://archive.ubuntu.com/ubuntu precise-updates main restricted universe
+
+deb-i386 http://archive.ubuntu.com/ubuntu precise main restricted universe
+deb-i386 http://archive.ubuntu.com/ubuntu precise-security main restricted universe
+deb-i386 http://archive.ubuntu.com/ubuntu precise-updates main restricted universe
+
+## Ubuntu trusty (14.04)
+deb http://archive.ubuntu.com/ubuntu trusty main restricted universe
+deb http://archive.ubuntu.com/ubuntu trusty-security main restricted universe
+deb http://archive.ubuntu.com/ubuntu trusty-updates main restricted universe
+
+deb-i386 http://archive.ubuntu.com/ubuntu trusty main restricted universe
+deb-i386 http://archive.ubuntu.com/ubuntu trusty-security main restricted universe
+deb-i386 http://archive.ubuntu.com/ubuntu trusty-updates main restricted universe

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 apt-mirror
 ==========
+For the original apt-mirror please see: http://apt-mirror.github.com
 
-See: http://apt-mirror.github.com
+Our apt-mirror variant
+=================
+This variant of the apt-mirror, allows for setting a size limit for a package to be downloaded.
+It also allows setting up exclusion rules for packages based on the section they belong to or their name patterns.
+At the moment the script only allows configuration via changing the script itself, we hope to change to using the configuration file for this purpose.
+
+The origin of the idea came from the blog page of Tyler Oderkirk
+http://unsyncopated.com/blog/index.php/2009/11/04/creating-a-local-mirror-of-ubuntus-most-popular-packages/
+
+The intent of this package is to create a subset of distribution for a community such as a school, college, hostel etc where people require a known subset of the packages based on either their language or some other package preferences, and to allow evolving it over a period of time.
+
+P.S. I am currently new to perl so all help and suggestions are welcome.

--- a/README.md
+++ b/README.md
@@ -13,4 +13,10 @@ http://unsyncopated.com/blog/index.php/2009/11/04/creating-a-local-mirror-of-ubu
 
 The intent of this package is to create a subset of distribution for a community such as a school, college, hostel etc where people require a known subset of the packages based on either their language or some other package preferences, and to allow evolving it over a period of time.
 
-P.S. I am currently new to perl so all help and suggestions are welcome.
+Why would you need a distribution of your own?
+=====================================
+To save on internet bandwidth by avoiding downloading the same content over and over again for each device/pc/os instance. This especially helps if one is interested in switiching between versions of packages frequently.
+
+Got suggestions/tips for a perl noob
+============================
+All the help and suggestions are most welcome.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,75 @@ http://unsyncopated.com/blog/index.php/2009/11/04/creating-a-local-mirror-of-ubu
 
 The intent of this package is to create a subset of distribution for a community such as a school, college, hostel etc where people require a known subset of the packages based on either their language or some other package preferences, and to allow evolving it over a period of time.
 
+Some important notes
+====================
+While mirroring if one needs to skip a certain set of packages, this
+can be configured in the config file, by using skip and exception configuration.
+A skip configuration line look like
+
+    skip <criteria> {except <criteria>} reason <some text explaining the intent of this skip for logging>
+
+An exception configuration line look like
+
+    exception <criteria> reason <some text explaining the intent of this exception for logging>
+
+The following criteria are valid:
+    * size_more_than <size in bytes> e.g. size_more_than 10000000 : This means size more than 10M
+    * section <section name such as Games or Accessories> e.g. section Games
+    * if_name_contains <any text> e.g. if_name_contains cloud : Match packages with the text cloud in their names (case sensitive)
+    * if_name_ends_with <any text> e.g. if_name_ends_with locale-en : Match packages with the text locale-en at the end of their names (case sensitive) e.g. firefox-locale-en
+
+If spaces are given as input text then the text must be quoted using "(double quotes).
+e.g. exception if_name_contains git reason "because we like git"
+
+The reason is mandatory. The reason gets logged when a rule matches the given skip or exception criteria.
+e.g.
+        * Download exception granted for git because we like git
+        * Skipping clamav-dbg because it is more than 10MB
+
+The skip configuration can be used to skip packages based on any of the criteria definitions.
+Multiple such configurations can be specified on separate lines.
+To handle cases where the skip configuration matches a desired package or packages the except clause
+may be used with similar criteria as a part of the skip config line itself.
+If more than one rules cause a package to be skipped, the exception config line must be used.
+e.g. One might like sudoku package in games section. So the skip config might say that we do not
+wish to download any games and another config line might say skip any packages larger than 10MB.
+To prevent adding an except config to each of these skip config one can add a single exception config line.
+This will also safeguard it against future additions of skip config lines which could potentially cause
+a desirable package to be excluded.
+
+The files {base_path}/var/SKIP and {base_path}/var/EXCEPTION contain the results of the skip and exception config rules.
+Using these the user can get to know why a certain package was skipped or downloaded.
+
+How to configure?
+=================
+Please see the file AdvancedMirrorConfig.list for a sample config file. This file is in use for us. You can get a fair idea from this file. The intent of the file is to maintain packages for two distributions Ubuntu 12.04 and Ubuntu 14.04. We also like to switch between versions so the clean script is turned off. The script currently eliminates 139Gb+ worth of downloads for us which it would otherwise do because of our preferences. 
+
+Example 1:
+skip size_more_than 10000000 reason "because it is more than 10MB"
+
+Meaning: Skip any file with size more than 10MB and when logging to the SKIP file in log directory output something like "Skipping kde-workspace-data-extras because it is more than 10MB". This is a general rule we came up with to prevent downloading of excessively large packages. Our idea was to download large packages only when specifically requested for. See how the reason text is quoted this is done because we used multiple words with spaces. It is also important to us that this entire config occur on a single line so line breaks are not allowed.
+
+Example 2:
+skip section games reason "because it is a game package"
+
+Meaning: Skip any file which blongs to a section game and when logging to the SKIP file in log directory output something like "Skipping gnome-sudoku because it is a game package". This is a general rule we came up with to prevent downloading of any game packages.
+
+Example 3:
+skip if_name_contains dbg reason "because it is a debug package"
+
+Meaning: Skip any file whose package name contains the phrase dbg and when logging to SKIP file in log directory output something like "Skipping cups-dbg because it is a debug package". This is a rule we came up with to avoid downloading debug packages. These packages are supposed to contain debugging symbols for debugging said packages. In general we did not want to debug any ubuntu package itself, we wanted to be able to switch between different library and application versions but we are not interested at the moment in debugging any.
+
+Example 4:
+skip if_name_contains locale except if_name_contains locale-en except if_name_ends_with locale reason "because it is a non english locale package"
+
+Meaning: Here we wanted to skip locale packages since at our workplace we are usually only interested in english packages which are generally default. Also to cater for any exceptions to our understanding of the locale packaging, we choose to download the locale package if the name contains the text "locale-en" or if the name is simply "locale" to get the locale packages for english. In the log files we see log lines such as "Skipping firefox-locale-af because it is a non english locale package".
+
+Example 5:
+exception if_name_contains git reason "because we like git"
+
+Meaning: This relates to the other half of the skip configuration where we would like to download a package despite of the exception rules. We do this via exception and this example tells us to download a package if the name contains git. We noticed in our runs because of our size rule of 10MB git was getting excluded, but we here are fond of git and are frequently switching to newer versions to try them out. This exception rule will get all git packages for us. Correspondingly in the EXCEPTION log file we see "Download exception granted for git because we like git".
+
 Why would you need a distribution of your own?
 =====================================
 To save on internet bandwidth by avoiding downloading the same content over and over again for each device/pc/os instance. This especially helps if one is interested in switiching between versions of packages frequently.

--- a/apt-mirror
+++ b/apt-mirror
@@ -131,6 +131,8 @@ my %skipclean       = ();
 my %clean_directory = ();
 my @skip_configuration = ();
 my @exception_configuration = ();
+my $skip_size = 0;
+my $exception_size = 0;
 
 ######################################################################################
 ## Setting up $config_file variable
@@ -804,6 +806,7 @@ sub is_exception_granted_to_package
             {
                 ##The only other thing that can be present is a reason.
                 print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                $exception_size = $exception_size + $pkg_size;
                 return 1;
             }
         }
@@ -815,6 +818,7 @@ sub is_exception_granted_to_package
                 {
                     ##The only other thing that can be present is a reason.
                     print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                    $exception_size = $exception_size + $pkg_size;
                     return 1;
                 }
             }
@@ -826,6 +830,7 @@ sub is_exception_granted_to_package
                     {
                         ##The only other thing that can be present is a reason.
                         print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                        $exception_size = $exception_size + $pkg_size;
                         return 1;
                     }
                 }
@@ -837,6 +842,7 @@ sub is_exception_granted_to_package
                         {
                             ##The only other thing that can be present is a reason.
                             print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                            $exception_size = $exception_size + $pkg_size;
                             return 1;
                         }
                     }
@@ -917,6 +923,7 @@ sub handle_except_clause
     {
         $counter++;
         print FILES_SKIPPED "Skipping $package_name $params[$counter]\n";
+        $skip_size = $skip_size + $pkg_size;
         return 0;
     }
 }
@@ -939,6 +946,7 @@ sub handle_primary_criteria_match
         else
         {
             print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
+            $skip_size = $skip_size + $pkg_size;
             return 0;
         }
     }
@@ -1142,6 +1150,17 @@ my $need_bytes = 0;
 foreach ( values %urls_to_download )
 {
     $need_bytes += $_;
+}
+
+if( $skip_size != 0 )
+{
+    my $temp_size_output = format_bytes($skip_size);
+    print "$temp_size_output will be skipped because of the current skip configuration. See SKIP log file for details of packages skipped.\n";
+    if ( $exception_size != 0 )
+    {
+        $temp_size_output = format_bytes($exception_size);
+        print "$temp_size_output will be downloaded because of the current exception configuration. See EXCEPTION log file for details of packages which have been granted download exception.\n";
+    }
 }
 
 my $size_output = format_bytes($need_bytes);

--- a/apt-mirror
+++ b/apt-mirror
@@ -37,6 +37,44 @@ After you setup the configuration file you may run as root:
 
 Or uncomment the line in F</etc/cron.d/apt-mirror> to enable daily mirror updates.
 
+While mirroring if one needs to skip a certain set of packages, this
+can be configured in the config file, by using skip and exception configuration.
+A skip configuration line look like
+
+    skip <criteria> {except <criteria>} reason <some text explaining the intent of this skip for logging>
+
+An exception configuration line look like
+
+    exception <criteria> reason <some text explaining the intent of this exception for logging>
+
+The following criteria are valid:
+    * size_more_than <size in bytes> e.g. size_more_than 10000000 : This means size more than 10M
+    * section <section name such as Games or Accessories> e.g. section Games
+    * if_name_contains <any text> e.g. if_name_contains cloud : Match packages with the text cloud in their names (case sensitive)
+    * if_name_ends_with <any text> e.g. if_name_ends_with locale-en : Match packages with the text locale-en at the end of their names (case sensitive) e.g. firefox-locale-en
+
+If spaces are given as input text then the text must be quoted using "(double quotes).
+e.g. exception if_name_contains git reason "because we like git"
+
+The reason is mandatory. The reason gets logged when a rule matches the given skip or exception criteria.
+e.g.
+        * Download exception granted for git because we like git
+        * Skipping clamav-dbg because it is more than 10MB
+
+The skip configuration can be used to skip packages based on any of the criteria definitions.
+Multiple such configurations can be specified on separate lines.
+To handle cases where the skip configuration matches a desired package or packages the except clause
+may be used with similar criteria as a part of the skip config line itself.
+If more than one rules cause a package to be skipped, the exception config line must be used.
+e.g. One might like sudoku package in games section. So the skip config might say that we do not
+wish to download any games and another config line might say skip any packages larger than 10MB.
+To prevent adding an except config to each of these skip config one can add a single exception config line.
+This will also safeguard it against future additions of skip config lines which could potentially cause
+a desirable package to be excluded.
+
+The files {base_path}/var/SKIP and {base_path}/var/EXCEPTION contain the results of the skip and exception config rules.
+Using these the user can get to know why a certain package was skipped or downloaded.
+
 =head1 FILES
 
 F</etc/apt/mirror.list>
@@ -84,6 +122,7 @@ deb-src http://example.com/debian stable main contrib non-free
 
 Dmitry N. Hramtsov E<lt>hdn@nsu.ruE<gt>
 Brandon Holtsclaw E<lt>me@brandonholtsclaw.comE<gt>
+Sunny Narula E<lt>sunny@iandothers.orgE<gt>
 
 =cut
 

--- a/apt-mirror
+++ b/apt-mirror
@@ -95,6 +95,7 @@ use File::Path;
 use File::Basename;
 use Fcntl qw(:flock);
 use Scalar::Util qw(looks_like_number);
+use Text::ParseWords;
 
 my $config_file;
 
@@ -285,7 +286,9 @@ while (<CONFIG>)
 {
     next if /^\s*#/;
     next unless /\S/;
-    my @config_line = split;
+    my $line = $_;
+    $line =~ s/^\s+|\s+$//g;
+    my @config_line = parse_line('\s+', 0, $line);
     my $config_line = shift @config_line;
 
     if ( $config_line eq "set" )

--- a/apt-mirror
+++ b/apt-mirror
@@ -414,6 +414,40 @@ while (<CONFIG>)
 
     if ( $config_line eq "exception" )
     {
+        $length = $#config_line;
+        if ( ( $config_line[0] eq "size_more_than" ) || ( $config_line[0] eq "section" ) || ( $config_line[0] eq "if_name_contains" ) )
+        {
+            if ( $length < 1 )
+            {
+                die("apt-mirror: invalid config file specified $config_line[0] must be followed by a value and a reason ($.: $config_line ...)");
+            }
+            if ( $config_line[0] eq "size_more_than" )
+            {
+                if ( !looks_like_number ( $config_line[1] ) )
+                {
+                    die("apt-mirror: invalid config file specified size_more_than must be followed by a size value which must be a number value ($.: $config_line ...)");
+                }
+            }
+            if ( $length < 2 )
+            {
+                die("apt-mirror: invalid config file specified reason missing for skipping section ($.: $config_line ...)");
+            }
+            if ( $config_line[2] eq "reason" )
+            {
+                if ( $length < 3 )
+                {
+                    die("apt-mirror: invalid config file specified missing reason text ($.: $config_line ...)");
+                }
+            }
+            else
+            {
+                die("apt-mirror: invalid config file specified expected a reason here instead found $config_line[$counter] ($.: $config_line ...)");
+            }
+        }
+        else
+        {
+            die("apt-mirror: invalid config file specified not sure what to do with this line ($.: $config_line ...)");
+        }
         push ( @exception_configuration, [@config_line] );
         next;
     }

--- a/apt-mirror
+++ b/apt-mirror
@@ -786,6 +786,7 @@ open FILES_NEW, ">" . get_variable("var_path") . "/NEW" or die("apt-mirror: can'
 open FILES_MD5, ">" . get_variable("var_path") . "/MD5" or die("apt-mirror: can't write to intermediate file (MD5)");
 open FILES_SKIPPED, ">" . get_variable("var_path") . "/SKIP" or die("apt-mirror: can't write to intermediate file (SKIP)");
 open FILES_SKIP_EXCEPTION, ">" . get_variable("var_path") . "/EXCEPTION" or die("apt-mirror: can't write to intermediate file (EXCEPTION)");
+open FILES_SECTION , ">" . get_variable("var_path") . "/SECTION" or die("apt-mirror: can't write to intermediate file (SECTION)");
 
 my %stat_cache = ();
 
@@ -999,6 +1000,7 @@ sub should_process
     my $a_skip_config;
     my @params;
     my $max_size;
+    print FILES_SECTION "Package $pkg_name from section $section_name\n";
     for $a_skip_config (@skip_configuration)
     {
         @params = @$a_skip_config;

--- a/apt-mirror
+++ b/apt-mirror
@@ -335,90 +335,78 @@ while (<CONFIG>)
 
     if ( $config_line eq "skip" )
     {
-        $counter = 0;
         $length = $#config_line;
-        if ( $config_line[0] eq "size_more_than" )
+        if ( ( $config_line[0] eq "size_more_than" ) || ( $config_line[0] eq "section" ) || ( $config_line[0] eq "if_name_contains" ) )
         {
-            $counter++;
-            if ($counter <= $length)
+            if ( $length < 1 )
             {
-                if (looks_like_number($config_line[$counter]))
+                die("apt-mirror: invalid config file specified $config_line[0] must be followed by a value and a reason ($.: $config_line ...)");
+            }
+            if ( $config_line[0] eq "size_more_than" )
+            {
+                if ( !looks_like_number ( $config_line[1] ) )
+                {
+                    die("apt-mirror: invalid config file specified size_more_than must be followed by a size value which must be a number value ($.: $config_line ...)");
+                }
+            }
+            if ( $length < 2 )
+            {
+                die("apt-mirror: invalid config file specified reason missing for skipping section ($.: $config_line ...)");
+            }
+            else
+            {
+                ##Expecting an optional sequence of exception cases or a reason
+                $counter = 2;
+                while ( ( $counter <= $length) && ( $config_line[$counter] eq "except" ) )
                 {
                     $counter++;
-                    if ( $config_line[$counter] eq "reason" )
+                    if ( $counter > $length )
+                    {
+                        die("apt-mirror: invalid config file exception clause ($.: $config_line ...)");
+                    }
+                    if ( $config_line[$counter] eq "size_more_than" )
                     {
                         $counter++;
-                        if ($counter > $length)
+                        if ( $counter > $length )
                         {
-                            die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
+                            die("apt-mirror: invalid config file exception clause ($.: $config_line ...)");
+                        }
+                        if ( !looks_like_number ( $config_line[$counter] ) )
+                        {
+                            die("apt-mirror: invalid config file specified size_more_than must be followed by a size value which must be a number value ($.: $config_line ...)");
                         }
                     }
                     else
                     {
-                        die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
+                        $counter++;
+                    }
+                    if ( $counter > $length )
+                    {
+                        die("apt-mirror: invalid config file exception clause ($.: $config_line ...)");
+                    }
+                    $counter++;
+                }
+                if ( $counter > $length )
+                {
+                    die("apt-mirror: invalid config file reason not specified for skipping ($.: $config_line ...)");
+                }
+                if ( $config_line[$counter] eq "reason" )
+                {
+                    $counter++;
+                    if ($counter > $length)
+                    {
+                        die("apt-mirror: invalid config file specified missing reason text ($.: $config_line ...)");
                     }
                 }
                 else
                 {
-                    die("apt-mirror: invalid config file specified size_more_than must be followed by a size value which must be a number value");
+                    die("apt-mirror: invalid config file specified expected a reason here instead found $config_line[$counter] ($.: $config_line ...)");
                 }
-            }
-            else
-            {
-                die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
             }
         }
         else
         {
-            if ( $config_line[0] eq "section" )
-            {
-                if ( $#config_line < 1 )
-                {
-                    die("apt-mirror: invalid config file specified section must be followed by a section name and a reason");
-                }
-                else
-                {
-                    if ( $#config_line < 2 || ($config_line[2] ne "reason") )
-                    {
-                        die("apt-mirror: invalid config file specified reason missing for skipping section ($.: $config_line ...)");
-                    }
-                    else
-                    {
-                        if ( $#config_line < 3 )
-                        {
-                            die("apt-mirror: invalid config file specified reason text missing for skipping section ($.: $config_line ...)");
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if ( $config_line[0] eq "if_name_contains" )
-                {
-                    if ( $#config_line < 1 )
-                    {
-                        die("apt-mirror: invalid config file specified if_name_contains must be followed by a string to match");
-                    }
-                    else
-                    {
-                        if ( $#config_line < 2 || ($config_line[2] ne "reason") )
-                        {
-                            die("apt-mirror: invalid config file specified reason missing for if_name_contains ($.: $config_line ...)");
-                        }
-                        else
-                        {
-                            if ( $#config_line < 3 )
-                            {
-                                die("apt-mirror: invalid config file specified reason text missing for if_name_contains ($.: $config_line ...)");
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    die("apt-mirror: invalid config file specified not sure what to do with this line ($.: $config_line ...)");
-                }
-            }
+            die("apt-mirror: invalid config file specified not sure what to do with this line ($.: $config_line ...)");
         }
         push ( @skip_configuration, [@config_line] );
         next;
@@ -868,7 +856,6 @@ sub process_index_gz
         warn("apt-mirror: can't open index in process_index_gz");
         return;
     }
-
     while ( $package = <STREAM> )
     {
         local $/ = "\n";

--- a/apt-mirror
+++ b/apt-mirror
@@ -788,86 +788,205 @@ sub remove_spaces($)
 
 sub is_exception_granted_to_package
 {
-    #Lookup the package name and try to do a 100% match i.e. including version
     my $pkg_name = shift;
-    if ( ($pkg_name =~ /git/) || ($pkg_name =~ /3.16.0-31/) || ($pkg_name =~ /gcc/) )
+    my $section_name = shift;
+    my $pkg_size = shift;
+    my $max_size;
+    my $an_exception_config;
+    my @params;
+    for $an_exception_config (@exception_configuration)
     {
-        print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name\n";
-        return 1;
+        @params = @$an_exception_config;
+        if( $params[0] eq "size_more_than" )
+        {
+            $max_size = $params[1];
+            if( $pkg_size > $max_size )
+            {
+                ##The only other thing that can be present is a reason.
+                print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                return 1;
+            }
+        }
+        else
+        {
+            if( $params[0] eq "section" )
+            {
+                if ($section_name eq $params[1])
+                {
+                    ##The only other thing that can be present is a reason.
+                    print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                    return 1;
+                }
+            }
+            else
+            {
+                ##Must be the if_name_contains
+                if ( index( $pkg_name, $params[1]) != -1 )
+                {
+                    ##The only other thing that can be present is a reason.
+                    print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                    return 1;
+                }
+            }
+        }
     }
     return 0;
 }
-
+sub handle_except_clause
+{
+    ##Handle sequence of except clauses
+    my ($counter, $package_name, $section_name, $pkg_size, $array_ref) = @_;
+    my @params = @$array_ref;
+    $counter++;
+    if( $params[$counter] eq "size_more_than" )
+    {
+        $counter++;
+        my $max_size = $params[$counter];
+        if( $pkg_size > $max_size )
+        {
+            return 1;
+        }
+    }
+    else
+    {
+        if( ( $params[$counter] eq "section" ) )
+        {
+            $counter++;
+            if( $section_name eq $params[$counter] )
+            {
+                return 1;
+            }
+        }
+        else
+        {
+            ##This must be the if_name_contains
+            $counter++;
+            if( index($package_name, $params[$counter]) != -1 )
+            {
+                return 1;
+            }
+        }
+    }
+    $counter++;
+    ##This except clause did not redeem the package, check if there is another one
+    if( $params[$counter] eq "except" )
+    {
+        return handle_except_clause($counter, $package_name, $section_name, $pkg_size, \@params);
+    }
+    ##The next word is obviously reason now check if a global exception redeems the package
+    if( is_exception_granted_to_package( $package_name, $section_name, $pkg_size ))
+    {
+        return 1;
+    }
+    else
+    {
+        $counter++;
+        print FILES_SKIPPED "Skipping $package_name $params[$counter]\n";
+        return 0;
+    }
+}
 sub should_process
 {
     my $pkg_name = shift;
     my $section_name = shift;
     my $pkg_size = shift;
     #Skip packages based on configuration
-    if ( $section_name !~ /game/ )
+    my $a_skip_config;
+    my @params;
+    my $max_size;
+    for $a_skip_config (@skip_configuration)
     {
-        if ( $pkg_size < 10000000 )
+        @params = @$a_skip_config;
+        if( $params[0] eq "size_more_than" )
         {
-            if ( $pkg_name =~ /dbg/)
+            $max_size = $params[1];
+            if( $pkg_size > $max_size )
             {
-                if( is_exception_granted_to_package( $pkg_name ) )
+                ##Continue to check if an exception applies
+                if( $params[2] eq "except" )
                 {
-                    return 1;
+                    return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
                 }
                 else
                 {
-                    print FILES_SKIPPED "Skipping $pkg_name because it is a debug package\n";
-                    return 0;
-                }
-            }
-            if ( ($pkg_name =~ /linux-image/) || ($pkg_name =~ /linux-headers/) || ($pkg_name =~ /linux-backports/) || ($pkg_name =~ /linux-tools/) || ($pkg_name =~ /cloud/) || ($pkg_name =~ /linux-generic/) || ($pkg_name =~ /linux-lts-trusty-tools/) )
-            {
-                if( is_exception_granted_to_package( $pkg_name ) )
-                {
-                    return 1;
-                }
-                else
-                {
-                    print FILES_SKIPPED "Skipping $pkg_name because it is a kernel package\n";
-                    return 0;
-                }
-            }
-            if( ($pkg_name =~ /locale/) )
-            {
-                if($pkg_name !~ /locale-en/)
-                {
-                    if( is_exception_granted_to_package( $pkg_name ) )
+                    ##The only other thing that can be present is a reason.
+                    if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
                     {
                         return 1;
                     }
                     else
                     {
-                        print FILES_SKIPPED "Skipping $pkg_name because it is a non english locale package\n";
+                        print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
                         return 0;
                     }
                 }
-                return 1;
-            }
-            return 1;
-        }
-        else
-        {
-            if( is_exception_granted_to_package( $pkg_name ) )
-            {
-                return 1;
             }
             else
             {
-                print FILES_SKIPPED "Skipping $pkg_name because it is more than 10MB($pkg_size)\n";
-                return 0;
+                next;
+            }
+        }
+        else
+        {
+            if( $params[0] eq "section" )
+            {
+                if ($section_name eq $params[1])
+                {
+                    if( $params[2] eq "except" )
+                    {
+                        return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
+                    }
+                    else
+                    {
+                        ##The only other thing that can be present is a reason.
+                        if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
+                        {
+                            return 1;
+                        }
+                        else
+                        {
+                            print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
+                            return 0;
+                        }
+                    }
+                }
+                else
+                {
+                    next;
+                }
+            }
+            else
+            {
+                ##Must be the if_name_contains
+                if ( index($pkg_name, $params[1]) != -1 )
+                {
+                    if( $params[2] eq "except" )
+                    {
+                        return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
+                    }
+                    else
+                    {
+                        ##The only other thing that can be present is a reason.
+                        if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
+                        {
+                            return 1;
+                        }
+                        else
+                        {
+                            print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
+                            return 0;
+                        }
+                    }
+                }
+                else
+                {
+                    next;
+                }
             }
         }
     }
-    else
-    {
-        print FILES_SKIPPED "Skipping $pkg_name because it is a game package\n";
-    }
-    return 0;
+    ##None of the rules apply so simply process the package
+    return 1;
 }
 
 sub process_index_gz

--- a/apt-mirror
+++ b/apt-mirror
@@ -920,6 +920,29 @@ sub handle_except_clause
         return 0;
     }
 }
+sub handle_primary_criteria_match
+{
+    my ($pkg_name, $section_name, $pkg_size, $array_ref) = @_;
+    my @params = @$array_ref;
+    ##Continue to check if an exception applies
+    if( $params[2] eq "except" )
+    {
+        return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
+    }
+    else
+    {
+        ##The only other thing that can be present is a reason.
+        if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
+        {
+            return 1;
+        }
+        else
+        {
+            print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
+            return 0;
+        }
+    }
+}
 sub should_process
 {
     my $pkg_name = shift;
@@ -937,24 +960,7 @@ sub should_process
             $max_size = $params[1];
             if( $pkg_size > $max_size )
             {
-                ##Continue to check if an exception applies
-                if( $params[2] eq "except" )
-                {
-                    return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
-                }
-                else
-                {
-                    ##The only other thing that can be present is a reason.
-                    if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
-                    {
-                        return 1;
-                    }
-                    else
-                    {
-                        print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
-                        return 0;
-                    }
-                }
+                return handle_primary_criteria_match($pkg_name, $section_name, $pkg_size, \@params);
             }
             else
             {
@@ -967,23 +973,7 @@ sub should_process
             {
                 if ($section_name eq $params[1])
                 {
-                    if( $params[2] eq "except" )
-                    {
-                        return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
-                    }
-                    else
-                    {
-                        ##The only other thing that can be present is a reason.
-                        if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
-                        {
-                            return 1;
-                        }
-                        else
-                        {
-                            print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
-                            return 0;
-                        }
-                    }
+                    return handle_primary_criteria_match($pkg_name, $section_name, $pkg_size, \@params);
                 }
                 else
                 {
@@ -996,23 +986,7 @@ sub should_process
                 {
                     if ( index($pkg_name, $params[1]) != -1 )
                     {
-                        if( $params[2] eq "except" )
-                        {
-                            return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
-                        }
-                        else
-                        {
-                            ##The only other thing that can be present is a reason.
-                            if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
-                            {
-                                return 1;
-                            }
-                            else
-                            {
-                                print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
-                                return 0;
-                            }
-                        }
+                        return handle_primary_criteria_match($pkg_name, $section_name, $pkg_size, \@params);
                     }
                     else
                     {
@@ -1025,23 +999,7 @@ sub should_process
                     {
                         if ( index($pkg_name, $params[1]) == length($pkg_name)-length($params[1]) )
                         {
-                            if( $params[2] eq "except" )
-                            {
-                                return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
-                            }
-                            else
-                            {
-                                ##The only other thing that can be present is a reason.
-                                if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
-                                {
-                                    return 1;
-                                }
-                                else
-                                {
-                                    print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
-                                    return 0;
-                                }
-                            }
+                            return handle_primary_criteria_match($pkg_name, $section_name, $pkg_size, \@params);
                         }
                         else
                         {

--- a/apt-mirror
+++ b/apt-mirror
@@ -391,6 +391,34 @@ while (<CONFIG>)
                     }
                 }
             }
+            else
+            {
+                if ( $config_line[0] eq "if_name_contains" )
+                {
+                    if ( $#config_line < 1 )
+                    {
+                        die("apt-mirror: invalid config file specified if_name_contains must be followed by a string to match");
+                    }
+                    else
+                    {
+                        if ( $#config_line < 2 || ($config_line[2] ne "reason") )
+                        {
+                            die("apt-mirror: invalid config file specified reason missing for if_name_contains ($.: $config_line ...)");
+                        }
+                        else
+                        {
+                            if ( $#config_line < 3 )
+                            {
+                                die("apt-mirror: invalid config file specified reason text missing for if_name_contains ($.: $config_line ...)");
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    die("apt-mirror: invalid config file specified not sure what to do with this line ($.: $config_line ...)");
+                }
+            }
         }
         push ( @skip_configuration, [@config_line] );
         next;

--- a/apt-mirror
+++ b/apt-mirror
@@ -368,6 +368,30 @@ while (<CONFIG>)
                 die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
             }
         }
+        else
+        {
+            if ( $config_line[0] eq "section" )
+            {
+                if ( $#config_line < 1 )
+                {
+                    die("apt-mirror: invalid config file specified section must be followed by a section name and a reason");
+                }
+                else
+                {
+                    if ( $#config_line < 2 || ($config_line[2] ne "reason") )
+                    {
+                        die("apt-mirror: invalid config file specified reason missing for skipping section ($.: $config_line ...)");
+                    }
+                    else
+                    {
+                        if ( $#config_line < 3 )
+                        {
+                            die("apt-mirror: invalid config file specified reason text missing for skipping section ($.: $config_line ...)");
+                        }
+                    }
+                }
+            }
+        }
         push ( @skip_configuration, [@config_line] );
         next;
     }

--- a/apt-mirror
+++ b/apt-mirror
@@ -617,6 +617,8 @@ foreach ( keys %urls_to_download )
 open FILES_ALL, ">" . get_variable("var_path") . "/ALL" or die("apt-mirror: can't write to intermediate file (ALL)");
 open FILES_NEW, ">" . get_variable("var_path") . "/NEW" or die("apt-mirror: can't write to intermediate file (NEW)");
 open FILES_MD5, ">" . get_variable("var_path") . "/MD5" or die("apt-mirror: can't write to intermediate file (MD5)");
+open FILES_SKIPPED, ">" . get_variable("var_path") . "/SKIP" or die("apt-mirror: can't write to intermediate file (SKIP)");
+open FILES_SKIP_EXCEPTION, ">" . get_variable("var_path") . "/EXCEPTION" or die("apt-mirror: can't write to intermediate file (EXCEPTION)");
 
 my %stat_cache = ();
 
@@ -658,6 +660,90 @@ sub remove_spaces($)
     }
 }
 
+sub is_exception_granted_to_package
+{
+    #Lookup the package name and try to do a 100% match i.e. including version
+    my $pkg_name = shift;
+    if ( ($pkg_name =~ /git/) || ($pkg_name =~ /3.16.0-31/) || ($pkg_name =~ /gcc/) )
+    {
+        print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name\n";
+        return 1;
+    }
+    return 0;
+}
+
+sub should_process
+{
+    my $pkg_name = shift;
+    my $section_name = shift;
+    my $pkg_size = shift;
+    #Skip packages based on configuration
+    if ( $section_name !~ /game/ )
+    {
+        if ( $pkg_size < 10000000 )
+        {
+            if ( $pkg_name =~ /dbg/)
+            {
+                if( is_exception_granted_to_package( $pkg_name ) )
+                {
+                    return 1;
+                }
+                else
+                {
+                    print FILES_SKIPPED "Skipping $pkg_name because it is a debug package\n";
+                    return 0;
+                }
+            }
+            if ( ($pkg_name =~ /linux-image/) || ($pkg_name =~ /linux-headers/) || ($pkg_name =~ /linux-backports/) || ($pkg_name =~ /linux-tools/) || ($pkg_name =~ /cloud/) || ($pkg_name =~ /linux-generic/) || ($pkg_name =~ /linux-lts-trusty-tools/) )
+            {
+                if( is_exception_granted_to_package( $pkg_name ) )
+                {
+                    return 1;
+                }
+                else
+                {
+                    print FILES_SKIPPED "Skipping $pkg_name because it is a kernel package\n";
+                    return 0;
+                }
+            }
+            if( ($pkg_name =~ /locale/) )
+            {
+                if($pkg_name !~ /locale-en/)
+                {
+                    if( is_exception_granted_to_package( $pkg_name ) )
+                    {
+                        return 1;
+                    }
+                    else
+                    {
+                        print FILES_SKIPPED "Skipping $pkg_name because it is a non english locale package\n";
+                        return 0;
+                    }
+                }
+                return 1;
+            }
+            return 1;
+        }
+        else
+        {
+            if( is_exception_granted_to_package( $pkg_name ) )
+            {
+                return 1;
+            }
+            else
+            {
+                print FILES_SKIPPED "Skipping $pkg_name because it is more than 10MB($pkg_size)\n";
+                return 0;
+            }
+        }
+    }
+    else
+    {
+        print FILES_SKIPPED "Skipping $pkg_name because it is a game package\n";
+    }
+    return 0;
+}
+
 sub process_index_gz
 {
     my $uri   = shift;
@@ -697,7 +783,10 @@ sub process_index_gz
             if ( need_update( $mirror . "/" . $lines{"Filename:"}, $lines{"Size:"} ) )
             {
                 print FILES_NEW remove_double_slashes( $uri . "/" . $lines{"Filename:"} ) . "\n";
-                add_url_to_download( $uri . "/" . $lines{"Filename:"}, $lines{"Size:"} );
+                if( should_process( $lines{"Package:"}, $lines{"Section:"}, $lines{"Size:"} ) )
+                {
+                    add_url_to_download( $uri . "/" . $lines{"Filename:"}, $lines{"Size:"} );
+                }
             }
         }
         else
@@ -713,7 +802,10 @@ sub process_index_gz
                 if ( need_update( $mirror . "/" . $lines{"Directory:"} . "/" . $file[2], $file[1] ) )
                 {
                     print FILES_NEW remove_double_slashes( $uri . "/" . $lines{"Directory:"} . "/" . $file[2] ) . "\n";
-                    add_url_to_download( $uri . "/" . $lines{"Directory:"} . "/" . $file[2], $file[1] );
+                    if( should_process( $lines{"Package:"}, $lines{"Section:"}, $lines{"Size:"} ) )
+                    {
+                        add_url_to_download( $uri . "/" . $lines{"Filename:"}, $lines{"Size:"} );
+                    }
                 }
             }
         }

--- a/apt-mirror
+++ b/apt-mirror
@@ -127,6 +127,8 @@ my @index_urls;
 my @childrens       = ();
 my %skipclean       = ();
 my %clean_directory = ();
+my @skip_configuration = ();
+my @exception_configuration = ();
 
 ######################################################################################
 ## Setting up $config_file variable
@@ -323,6 +325,18 @@ while (<CONFIG>)
         $config_line[0] =~ s[/$][];
         $config_line[0] =~ s[~][%7E]g if get_variable("_tilde");
         $clean_directory{ $config_line[0] } = 1;
+        next;
+    }
+
+    if ( $config_line eq "skip" )
+    {
+        push ( @skip_configuration, [@config_line] );
+        next;
+    }
+
+    if ( $config_line eq "exception" )
+    {
+        push ( @exception_configuration, [@config_line] );
         next;
     }
 

--- a/apt-mirror
+++ b/apt-mirror
@@ -94,6 +94,7 @@ use File::Compare;
 use File::Path;
 use File::Basename;
 use Fcntl qw(:flock);
+use Scalar::Util qw(looks_like_number);
 
 my $config_file;
 
@@ -277,7 +278,8 @@ sub download_urls
 }
 
 ## Parse config
-
+my $counter;
+my $length;
 open CONFIG, "<$config_file" or die("apt-mirror: can't open config file ($config_file)");
 while (<CONFIG>)
 {
@@ -330,6 +332,39 @@ while (<CONFIG>)
 
     if ( $config_line eq "skip" )
     {
+        $counter = 0;
+        $length = $#config_line;
+        if ( $config_line[0] eq "size_more_than" )
+        {
+            $counter++;
+            if ($counter <= $length)
+            {
+                if (looks_like_number($config_line[$counter]))
+                {
+                    $counter++;
+                    if ( $config_line[$counter] eq "reason" )
+                    {
+                        $counter++;
+                        if ($counter > $length)
+                        {
+                            die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
+                        }
+                    }
+                    else
+                    {
+                        die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
+                    }
+                }
+                else
+                {
+                    die("apt-mirror: invalid config file specified size_more_than must be followed by a size value which must be a number value");
+                }
+            }
+            else
+            {
+                die("apt-mirror: invalid config file specified size_more_than must be followed by a size value and a reason");
+            }
+        }
         push ( @skip_configuration, [@config_line] );
         next;
     }

--- a/apt-mirror
+++ b/apt-mirror
@@ -336,7 +336,7 @@ while (<CONFIG>)
     if ( $config_line eq "skip" )
     {
         $length = $#config_line;
-        if ( ( $config_line[0] eq "size_more_than" ) || ( $config_line[0] eq "section" ) || ( $config_line[0] eq "if_name_contains" ) )
+        if ( ( $config_line[0] eq "size_more_than" ) || ( $config_line[0] eq "section" ) || ( $config_line[0] eq "if_name_contains" )  || ( $config_line[0] eq "if_name_ends_with" ))
         {
             if ( $length < 1 )
             {
@@ -415,7 +415,7 @@ while (<CONFIG>)
     if ( $config_line eq "exception" )
     {
         $length = $#config_line;
-        if ( ( $config_line[0] eq "size_more_than" ) || ( $config_line[0] eq "section" ) || ( $config_line[0] eq "if_name_contains" ) )
+        if ( ( $config_line[0] eq "size_more_than" ) || ( $config_line[0] eq "section" ) || ( $config_line[0] eq "if_name_contains" )  || ( $config_line[0] eq "if_name_ends_with" ) )
         {
             if ( $length < 1 )
             {
@@ -820,12 +820,30 @@ sub is_exception_granted_to_package
             }
             else
             {
-                ##Must be the if_name_contains
-                if ( index( $pkg_name, $params[1]) != -1 )
+                if( $params[0] eq "if_name_contains" )
                 {
-                    ##The only other thing that can be present is a reason.
-                    print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
-                    return 1;
+                    if ( index( $pkg_name, $params[1]) != -1 )
+                    {
+                        ##The only other thing that can be present is a reason.
+                        print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                        return 1;
+                    }
+                }
+                else
+                {
+                    if( $params[0] eq "if_name_ends_with" )
+                    {
+                        if ( index( $pkg_name, $params[1]) == length($pkg_name)-length($params[1]) )
+                        {
+                            ##The only other thing that can be present is a reason.
+                            print FILES_SKIP_EXCEPTION "Download exception granted for $pkg_name $params[3]\n";
+                            return 1;
+                        }
+                    }
+                    else
+                    {
+                        die("apt-mirror: not sure what $params[$counter] means");
+                    }
                 }
             }
         }
@@ -859,11 +877,28 @@ sub handle_except_clause
         }
         else
         {
-            ##This must be the if_name_contains
-            $counter++;
-            if( index($package_name, $params[$counter]) != -1 )
+            if( ( $params[$counter] eq "if_name_contains" ) )
             {
-                return 1;
+                $counter++;
+                if( index($package_name, $params[$counter]) != -1 )
+                {
+                    return 1;
+                }
+            }
+            else
+            {
+                if( ( $params[$counter] eq "if_name_ends_with" ) )
+                {
+                    $counter++;
+                    if( index($package_name, $params[$counter]) == length($package_name)-length($params[$counter]) )
+                    {
+                        return 1;
+                    }
+                }
+                else
+                {
+                    die("apt-mirror: not sure what $params[$counter] means");
+                }
             }
         }
     }
@@ -957,30 +992,66 @@ sub should_process
             }
             else
             {
-                ##Must be the if_name_contains
-                if ( index($pkg_name, $params[1]) != -1 )
+                if( $params[0] eq "if_name_contains" )
                 {
-                    if( $params[2] eq "except" )
+                    if ( index($pkg_name, $params[1]) != -1 )
                     {
-                        return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
-                    }
-                    else
-                    {
-                        ##The only other thing that can be present is a reason.
-                        if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
+                        if( $params[2] eq "except" )
                         {
-                            return 1;
+                            return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
                         }
                         else
                         {
-                            print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
-                            return 0;
+                            ##The only other thing that can be present is a reason.
+                            if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
+                            {
+                                return 1;
+                            }
+                            else
+                            {
+                                print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
+                                return 0;
+                            }
                         }
+                    }
+                    else
+                    {
+                        next;
                     }
                 }
                 else
                 {
-                    next;
+                    if( $params[0] eq "if_name_ends_with" )
+                    {
+                        if ( index($pkg_name, $params[1]) == length($pkg_name)-length($params[1]) )
+                        {
+                            if( $params[2] eq "except" )
+                            {
+                                return handle_except_clause(2, $pkg_name, $section_name, $pkg_size, \@params);
+                            }
+                            else
+                            {
+                                ##The only other thing that can be present is a reason.
+                                if( is_exception_granted_to_package( $pkg_name, $section_name, $pkg_size ) )
+                                {
+                                    return 1;
+                                }
+                                else
+                                {
+                                    print FILES_SKIPPED "Skipping $pkg_name $params[3]\n";
+                                    return 0;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            next;
+                        }
+                    }
+                    else
+                    {
+                        die("apt-mirror: not sure what $params[0] means");
+                    }
                 }
             }
         }


### PR DESCRIPTION
When building an apt-mirror for an organization such as a school, college or a private institution, certain customization rules can be figured to allow saving on bandwidth and storage space.