### PR TITLE
Update Apt-mirror

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -253,8 +253,7 @@ sub download_urls
 
         if ( $pid == 0 )
         {
-            exec 'wget', '--no-cache', '--limit-rate=' . get_variable("limit_rate"), '-t', '5', '-r', '-N', '-l', 'inf', '-o', get_variable("var_path") . "/$stage-log.$i", '-i', get_variable("var_path") . "/$stage-urls.$i", @args;
-
+            exec 'wget', '--no-cache', '--retry-connrefused', '--waitretry=2', '--read-timeout=12', '--dns-timeout=3', '--connect-timeout=3', '--tries=5', '--limit-rate=' . get_variable("limit_rate"), '-r', '-N', '-l', 'inf', '-o', get_variable("var_path") . "/$stage-log.$i", '-i', get_variable("var_path") . "/$stage-urls.$i", @args;
             # shouldn't reach this unless exec fails
             die("\n\nCould not run wget, please make sure its installed and in your path\n\n");
         }


### PR DESCRIPTION
Behaves better when a repository is not available or with bad connections (previous version almost hangs for a while)