### PR TITLE
Support config variable values with spaces in mirror.list

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -286,7 +286,7 @@ while (<CONFIG>)
 
     if ( $config_line eq "set" )
     {
-        $config_variables{ $config_line[0] } = $config_line[1];
+        $config_variables{ $config_line[0] } = join(' ', @config_line[1..$#config_line]);
         next;
     }
 


### PR DESCRIPTION
When parsing a `set` line, use all the remaining fields in the space-separated list as the variable value, so that a value with spaces is retrieved properly. This is especially useful for paths with spaces inside them (without this modification there is no way to use such a path).