### PR TITLE
Include debian-installer components into the mirroring.

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -427,6 +427,10 @@ foreach (@config_binaries)
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.gz" );
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.bz2" );
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.xz" );
+            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Release" );
+            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Packages.gz" );
+            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Packages.bz2" );
+            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Packages.xz" );
             add_url_to_download( $url . $_ . "/i18n/Index" );
         }
     }
@@ -752,6 +756,7 @@ foreach (@config_binaries)
         foreach $component (@components)
         {
             process_index_gz( $uri, "/dists/$distribution/$component/binary-$arch/Packages.gz" );
+            process_index_gz( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );
         }
     }
     else


### PR DESCRIPTION
Thus, the mirrored repository can be used for a network installation.