### PR TITLE
Allow whitespace in config variable values

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -286,7 +286,13 @@ while (<CONFIG>)
 
     if ( $config_line eq "set" )
     {
-        $config_variables{ $config_line[0] } = $config_line[1];
+        # all set commands are 3 items on a line "set, variable, value", where the variable name may
+        # NOT contain whitespace but the value CAN - this allows file paths to contain whitespace
+
+        chomp;
+        s/^\s+//;
+        my ( $verb, $var, $value ) = split( /\s+/, $_, 3 );
+        $config_variables{$var} = $value;
         next;
     }
 
@@ -674,7 +680,7 @@ sub process_index_gz
 
     if ( $index =~ s/\.gz$// )
     {
-        system("gunzip < $path/$index.gz > $path/$index");
+        system(qq(gunzip < "$path/$index.gz" > "$path/$index"));
     }
 
     unless ( open STREAM, "<$path/$index" )


### PR DESCRIPTION
This fix allows apt-mirror to work when paths specified in the config file contain whitespace.

For example, our build process is in Continuous Integration under a folder named "Release Builds", which results in a working directory path like this:

     /var/lib/jenkins/jobs/Release Builds/jobs/1.0.3/workspace/mirror

using this as base_path fails, because the parser interprets base_path only to the first whitespace in the value.  

Even when this is fixed, the command line invocation of gunzip needs to be protected against whitespace in the paths by quoting the arguments on the command line.


