### PR TITLE
Debian 8.2 changes

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -98,7 +98,7 @@ use Fcntl qw(:flock);
 my $config_file;
 
 my %config_variables = (
-    "defaultarch" => `dpkg --print-architecture 2>/dev/null` || 'i386',
+    "defaultarch" => `dpkg --print-installation-architecture 2>/dev/null` || 'i386',
     "nthreads"    => 20,
     "base_path"   => '/var/spool/apt-mirror',
     "mirror_path" => '$base_path/mirror',
@@ -216,18 +216,9 @@ sub unlock_aptmirror
     unlink( get_variable("var_path") . "/apt-mirror.lock" );
 }
 
-sub download_urls
+sub wget_args
 {
-    my $stage = shift;
-    my @urls;
-    my $i = 0;
-    my $pid;
-    my $nthreads = get_variable("nthreads");
     my @args     = ();
-    local $| = 1;
-
-    @urls = @_;
-    $nthreads = @urls if @urls < $nthreads;
 
     if ( get_variable("auth_no_challenge") == 1 )    { push( @args, "--auth-no-challenge" ); }
     if ( get_variable("no_check_certificate") == 1 ) { push( @args, "--no-check-certificate" ); }
@@ -238,6 +229,25 @@ sub download_urls
         if ( length( get_variable("proxy_user") ) ) { push( @args, "-e proxy_user=" . get_variable("proxy_user") ); }
         if ( length( get_variable("proxy_password") ) ) { push( @args, "-e proxy_password=" . get_variable("proxy_password") ); }
     }
+
+	return @args;
+}
+
+sub download_urls
+{
+    my $stage = shift;
+    my @urls;
+    my $i = 0;
+    my $pid;
+    my $nthreads = get_variable("nthreads");
+#    my @args     = ();
+    local $| = 1;
+
+    @urls = @_;
+    $nthreads = @urls if @urls < $nthreads;
+
+	my @args = wget_args();
+
     print "Downloading " . scalar(@urls) . " $stage files using $nthreads threads...\n";
 
     while ( scalar @urls )
@@ -249,7 +259,7 @@ sub download_urls
 
         $pid = fork();
 
-        die("apt-mirror: can't do fork in download_urls") if !defined($pid);
+        die("apt-mirror: can't do fork in download_urls") if $pid < 0;
 
         if ( $pid == 0 )
         {
@@ -273,6 +283,8 @@ sub download_urls
     }
     print "\nEnd time: " . localtime() . "\n\n";
 }
+
+
 
 ## Parse config
 
@@ -369,6 +381,33 @@ sub add_url_to_download
     $urls_to_download{$url} = shift;
 }
 
+sub add_url_to_download_if_exists
+{
+    my $url = shift;
+    open(WGET, "wget --spider --no-cache $url 2>&1 |") or die "Can't exec: $!\n";
+    my @wget_output = <WGET>;
+    close(WGET);
+
+	if(grep(/Remote file exists/,@wget_output))
+    {
+        add_url_to_download($url);
+    }
+    else
+    # We didn't find this on the mirror, so check we don't have a stale local copy
+    {
+        my $path = sanitise_uri($url);
+        foreach my $type ((qw(mirror_path skel_path)))
+        {
+            my $type_path = get_variable($type) . "/" . $path;
+			if ( -e $type_path )
+            {
+                unlink($type_path);
+            }
+        }
+    }
+
+}
+
 foreach (@config_sources)
 {
     my ( $uri, $distribution, @components ) = @{$_};
@@ -377,24 +416,24 @@ foreach (@config_sources)
     {
         $url = $uri . "/dists/" . $distribution . "/";
 
-        add_url_to_download( $url . "InRelease" );
-        add_url_to_download( $url . "Release" );
-        add_url_to_download( $url . "Release.gpg" );
+        add_url_to_download_if_exists( $url . "InRelease" );
+        add_url_to_download_if_exists( $url . "Release" );
+        add_url_to_download_if_exists( $url . "Release.gpg" );
         foreach (@components)
         {
-            add_url_to_download( $url . $_ . "/source/Release" );
-            add_url_to_download( $url . $_ . "/source/Sources.gz" );
-            add_url_to_download( $url . $_ . "/source/Sources.bz2" );
-            add_url_to_download( $url . $_ . "/source/Sources.xz" );
+            add_url_to_download_if_exists( $url . $_ . "/source/Release" );
+            add_url_to_download_if_exists( $url . $_ . "/source/Sources.gz" );
+            add_url_to_download_if_exists( $url . $_ . "/source/Sources.bz2" );
+            add_url_to_download_if_exists( $url . $_ . "/source/Sources.xz" );
         }
     }
     else
     {
-        add_url_to_download( $uri . "/$distribution/Release" );
-        add_url_to_download( $uri . "/$distribution/Release.gpg" );
-        add_url_to_download( $uri . "/$distribution/Sources.gz" );
-        add_url_to_download( $uri . "/$distribution/Sources.bz2" );
-        add_url_to_download( $uri . "/$distribution/Sources.xz" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Release" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Release.gpg" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Sources.gz" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Sources.bz2" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Sources.xz" );
     }
 }
 
@@ -406,41 +445,40 @@ foreach (@config_binaries)
     {
         $url = $uri . "/dists/" . $distribution . "/";
 
-        add_url_to_download( $url . "InRelease" );
-        add_url_to_download( $url . "Release" );
-        add_url_to_download( $url . "Release.gpg" );
+        add_url_to_download_if_exists( $url . "InRelease" );
+        add_url_to_download_if_exists( $url . "Release" );
+        add_url_to_download_if_exists( $url . "Release.gpg" );
         if ( get_variable("_contents") )
         {
-            add_url_to_download( $url . "Contents-" . $arch . ".gz" );
-            add_url_to_download( $url . "Contents-" . $arch . ".bz2" );
-            add_url_to_download( $url . "Contents-" . $arch . ".xz" );
+            add_url_to_download_if_exists( $url . "Contents-" . $arch . ".gz" );
+            add_url_to_download_if_exists( $url . "Contents-" . $arch . ".bz2" );
+            add_url_to_download_if_exists( $url . "Contents-" . $arch . ".xz" );
         }
         foreach (@components)
         {
             if ( get_variable("_contents") )
             {
-                add_url_to_download( $url . $_ . "/Contents-" . $arch . ".gz" );
-                add_url_to_download( $url . $_ . "/Contents-" . $arch . ".bz2" );
-                add_url_to_download( $url . $_ . "/Contents-" . $arch . ".xz" );
+                add_url_to_download_if_exists( $url . $_ . "/Contents-" . $arch . ".gz" );
+                add_url_to_download_if_exists( $url . $_ . "/Contents-" . $arch . ".bz2" );
+                add_url_to_download_if_exists( $url . $_ . "/Contents-" . $arch . ".xz" );
+                get_diff_files($url . $_ . "/Contents-" . $arch . ".diff" );
             }
-            add_url_to_download( $url . $_ . "/binary-" . $arch . "/Release" );
-            add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.gz" );
-            add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.bz2" );
-            add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.xz" );
-            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Release" );
-            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Packages.gz" );
-            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Packages.bz2" );
-            add_url_to_download( $url . $_ . "/debian-installer/binary-" . $arch . "/Packages.xz" );
-            add_url_to_download( $url . $_ . "/i18n/Index" );
+            add_url_to_download_if_exists( $url . $_ . "/binary-" . $arch . "/Release" );
+            add_url_to_download_if_exists( $url . $_ . "/binary-" . $arch . "/Packages.gz" );
+            add_url_to_download_if_exists( $url . $_ . "/binary-" . $arch . "/Packages.bz2" );
+            add_url_to_download_if_exists( $url . $_ . "/binary-" . $arch . "/Packages.xz" );
+            get_diff_files($url . $_ . "/binary-" . $arch . ".diff" );
+            add_url_to_download_if_exists( $url . $_ . "/binary-" . $arch . ".diff/Index" );
+            add_url_to_download_if_exists( $url . $_ . "/i18n/Index" );
         }
     }
     else
     {
-        add_url_to_download( $uri . "/$distribution/Release" );
-        add_url_to_download( $uri . "/$distribution/Release.gpg" );
-        add_url_to_download( $uri . "/$distribution/Packages.gz" );
-        add_url_to_download( $uri . "/$distribution/Packages.bz2" );
-        add_url_to_download( $uri . "/$distribution/Packages.xz" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Release" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Release.gpg" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Packages.gz" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Packages.bz2" );
+        add_url_to_download_if_exists( $uri . "/$distribution/Packages.xz" );
     }
 }
 
@@ -583,7 +621,7 @@ sub process_translation_index
     close STREAM;
 }
 
-print "Processing translation indexes: [";
+print "Processing tranlation indexes: [";
 
 foreach (@config_binaries)
 {
@@ -756,7 +794,6 @@ foreach (@config_binaries)
         foreach $component (@components)
         {
             process_index_gz( $uri, "/dists/$distribution/$component/binary-$arch/Packages.gz" );
-            process_index_gz( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );
         }
     }
     else
@@ -790,6 +827,48 @@ print "$size_output will be downloaded into archive.\n";
 
 download_urls( "archive", sort keys %urls_to_download );
 
+######################################################################################
+## Process .diff directory
+
+sub get_diff_files
+{
+    my $diff_dir = shift;
+    my $diff_url = $diff_dir . "/Index";
+    my @diff_files= ();
+
+    open(WGET, '-|', 'wget', '--quiet', '--no-cache', '-O', '-', $diff_url) or die "Can't exec: $!\n";
+
+    while(my $wget_line = <WGET>)
+    {
+
+        if($wget_line=~/^ /)
+        {
+			my $file_name=(split(/\s+/,$wget_line))[-1];
+
+            if(!(grep(/$file_name/,@diff_files)))
+            {
+                push(@diff_files,$diff_dir . "/" . $file_name . ".gz");
+            }
+
+        }
+
+    } 
+
+    close(WGET);
+
+    if((@diff_files)>0)
+    {
+
+        add_url_to_download($diff_url);
+
+        foreach my $diff (@diff_files)
+        {
+            add_url_to_download($diff);
+        }
+
+    }
+
+}
 ######################################################################################
 ## Copy skel to main archive
 

--- a/apt-mirror
+++ b/apt-mirror
@@ -240,13 +240,12 @@ sub download_urls
     my $i = 0;
     my $pid;
     my $nthreads = get_variable("nthreads");
-#    my @args     = ();
     local $| = 1;
 
     @urls = @_;
     $nthreads = @urls if @urls < $nthreads;
 
-	my @args = wget_args();
+    my @args = wget_args();
 
     print "Downloading " . scalar(@urls) . " $stage files using $nthreads threads...\n";
 
@@ -259,7 +258,7 @@ sub download_urls
 
         $pid = fork();
 
-        die("apt-mirror: can't do fork in download_urls") if $pid < 0;
+        die("apt-mirror: can't do fork in download_urls") if !defined($pid);
 
         if ( $pid == 0 )
         {
@@ -794,7 +793,7 @@ foreach (@config_binaries)
         foreach $component (@components)
         {
             process_index_gz( $uri, "/dists/$distribution/$component/binary-$arch/Packages.gz" );
-            process_index_gz( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );:w
+            process_index_gz( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );
         }
     }
     else

--- a/apt-mirror
+++ b/apt-mirror
@@ -98,7 +98,7 @@ use Fcntl qw(:flock);
 my $config_file;
 
 my %config_variables = (
-    "defaultarch" => `dpkg --print-installation-architecture 2>/dev/null` || 'i386',
+    "defaultarch" => `dpkg --print-architecture 2>/dev/null` || 'i386',
     "nthreads"    => 20,
     "base_path"   => '/var/spool/apt-mirror',
     "mirror_path" => '$base_path/mirror',
@@ -621,7 +621,7 @@ sub process_translation_index
     close STREAM;
 }
 
-print "Processing tranlation indexes: [";
+print "Processing translation indexes: [";
 
 foreach (@config_binaries)
 {
@@ -794,6 +794,7 @@ foreach (@config_binaries)
         foreach $component (@components)
         {
             process_index_gz( $uri, "/dists/$distribution/$component/binary-$arch/Packages.gz" );
+            process_index_gz( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );:w
         }
     }
     else

--- a/apt-mirror
+++ b/apt-mirror
@@ -840,34 +840,28 @@ sub get_diff_files
 
     while(my $wget_line = <WGET>)
     {
-
         if($wget_line=~/^ /)
         {
-			my $file_name=(split(/\s+/,$wget_line))[-1];
+            my $file_name=(split(/\s+/,$wget_line))[-1];
 
             if(!(grep(/$file_name/,@diff_files)))
             {
                 push(@diff_files,$diff_dir . "/" . $file_name . ".gz");
             }
-
         }
-
     } 
 
     close(WGET);
 
     if((@diff_files)>0)
     {
-
         add_url_to_download($diff_url);
 
         foreach my $diff (@diff_files)
         {
             add_url_to_download($diff);
         }
-
     }
-
 }
 ######################################################################################
 ## Copy skel to main archive


### PR DESCRIPTION
While investigating issues with my Debian 8 mirror, I found this issue https://github.com/apt-mirror/apt-mirror/issues/45 where it seems some stale files are getting left behind.

I've added validation that the definition files (InRelease/Release/Contents/Packages) are actually present on the remote mirror before trying to download them, and if they're not then purge them from the local disk).  Also now tries to process/mirror .diff directories that seem to be on the mirrors now

The negative trade off is that at start up there's a load of extra checking for what is/is not present on the remote mirror with wget --spider, but I think it results in a more current sync.