### PR TITLE
Download DEP-11 files in component/dep11 directories.

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -614,6 +614,96 @@ foreach ( keys %urls_to_download )
 }
 
 ######################################################################################
+## DEP-11 index download
+
+%urls_to_download = ();
+
+sub find_dep11_files_in_release
+{
+    # Look in the dists/$DIST/Release file for the DEP-11 files that belong
+    # to the given component.
+
+    my $dist_uri  = shift;
+    my $component = shift;
+    my ( $release_uri, $release_path, $line ) = '';
+
+    $release_uri  = $dist_uri . "Release";
+    $release_path = get_variable("skel_path") . "/" . sanitise_uri($release_uri);
+
+    unless ( open STREAM, "<$release_path" )
+    {
+        warn( "Failed to open Release file from " . $release_uri );
+        return;
+    }
+
+    my $checksums = 0;
+    while ( $line = <STREAM> )
+    {
+        chomp $line;
+        if ($checksums)
+        {
+            if ( $line =~ /^ +(.*)$/ )
+            {
+                my @parts = split( / +/, $1 );
+                if ( @parts == 3 )
+                {
+                    my ( $sha1, $size, $filename ) = @parts;
+                    if ( $filename =~ m{^$component/dep11/(Components-[^./]+\.yml|icons-[^./]+\.tar)\.gz$} )
+                    {
+                        add_url_to_download( $dist_uri . $filename, $size );
+                    }
+                }
+                else
+                {
+                    warn("Malformed checksum line \"$1\" in $release_uri");
+                }
+            }
+            else
+            {
+                $checksums = 0;
+            }
+        }
+        if ( not $checksums )
+        {
+            if ( $line eq "SHA256:" )
+            {
+                $checksums = 1;
+            }
+        }
+    }
+}
+
+print "Processing DEP-11 indexes: [";
+
+foreach (@config_binaries)
+{
+    my ( $arch, $uri, $distribution, @components ) = @{$_};
+    print "D";
+    if (@components)
+    {
+        $url = $uri . "/dists/" . $distribution . "/";
+
+        my $component;
+        foreach $component (@components)
+        {
+            find_dep11_files_in_release( $url, $component );
+        }
+    }
+}
+
+print "]\n\n";
+
+push( @index_urls, sort keys %urls_to_download );
+download_urls( "dep11", sort keys %urls_to_download );
+
+foreach ( keys %urls_to_download )
+{
+    s[^(\w+)://][];
+    s[~][%7E]g if get_variable("_tilde");
+    $skipclean{$_} = 1;
+}
+
+######################################################################################
 ## Main download preparations
 
 %urls_to_download = ();

--- a/apt-mirror
+++ b/apt-mirror
@@ -621,10 +621,11 @@ foreach ( keys %urls_to_download )
 sub find_dep11_files_in_release
 {
     # Look in the dists/$DIST/Release file for the DEP-11 files that belong
-    # to the given component.
+    # to the given component and architecture.
 
     my $dist_uri  = shift;
     my $component = shift;
+    my $arch      = shift;
     my ( $release_uri, $release_path, $line ) = '';
 
     $release_uri  = $dist_uri . "Release";
@@ -648,7 +649,7 @@ sub find_dep11_files_in_release
                 if ( @parts == 3 )
                 {
                     my ( $sha1, $size, $filename ) = @parts;
-                    if ( $filename =~ m{^$component/dep11/(Components-[^./]+\.yml|icons-[^./]+\.tar)\.gz$} )
+                    if ( $filename =~ m{^$component/dep11/(Components-${arch}\.yml|icons-[^./]+\.tar)\.gz$} )
                     {
                         add_url_to_download( $dist_uri . $filename, $size );
                     }
@@ -686,7 +687,7 @@ foreach (@config_binaries)
         my $component;
         foreach $component (@components)
         {
-            find_dep11_files_in_release( $url, $component );
+            find_dep11_files_in_release( $url, $component, $arch );
         }
     }
 }


### PR DESCRIPTION
Look in the Release file to select DEP-11 files relevant only for selected
architectures.

These files are new and present in Debian testing and Ubuntu xenial.
