### PR TITLE
Fix $path argument on calls to process_index_gz

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -737,12 +737,12 @@ foreach (@config_sources)
         my $component;
         foreach $component (@components)
         {
-            process_index_gz( $uri, "/dists/$distribution/$component/source/Sources.gz" );
+            process_index_gz( $uri, "dists/$distribution/$component/source/Sources.gz" );
         }
     }
     else
     {
-        process_index_gz( $uri, "/$distribution/Sources.gz" );
+        process_index_gz( $uri, "$distribution/Sources.gz" );
     }
 }
 
@@ -755,13 +755,13 @@ foreach (@config_binaries)
         my $component;
         foreach $component (@components)
         {
-            process_index_gz( $uri, "/dists/$distribution/$component/binary-$arch/Packages.gz" );
-            process_index_gz( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );
+            process_index_gz( $uri, "dists/$distribution/$component/binary-$arch/Packages.gz" );
+            process_index_gz( $uri, "dists/$distribution/$component/debian-installer/binary-$arch/Packages.gz" );
         }
     }
     else
     {
-        process_index_gz( $uri, "/$distribution/Packages.gz" );
+        process_index_gz( $uri, "$distribution/Packages.gz" );
     }
 }
 


### PR DESCRIPTION
The $path argument for current calls to process_index_gz start with a slash, resulting in commands such as
'gunzip < ftp.jaist.ac.jp/debian//dists/sid/non-free/binary-amd64/Packages.gz > ftp.jaist.ac.jp/debian/dists//sid/non-free/binary-amd64/Packages'
being executed. This command fixes all calls to process_index_gz so this does not happen.
