### PR TITLE
Download binary-all for all components

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -449,6 +449,11 @@ foreach (@config_binaries)
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.bz2" );
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.xz" );
             add_url_to_download( $url . $_ . "/i18n/Index" );
+
+            add_url_to_download( $url . $_ . "/binary-all/Release" );
+            add_url_to_download( $url . $_ . "/binary-all/Packages.gz" );
+            add_url_to_download( $url . $_ . "/binary-all/Packages.bz2" );
+            add_url_to_download( $url . $_ . "/binary-all/Packages.xz" );
         }
     }
     else


### PR DESCRIPTION
Some repositories, like puppetlabs [1], has binary-all in addition to
binary-$arch in the different components. These were not downloaded with
apt-mirror, and hence the local mirror was missing some files.

This commit fixes that by looking for the relevant files in every
mirrored component.

[1]: http://apt.puppetlabs.com/dists/stretch/PC1/binary-all/