### PR TITLE
fetch Packages even if it has no suffix

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -445,6 +445,7 @@ foreach (@config_binaries)
                 add_url_to_download( $url . $_ . "/Contents-" . $arch . ".xz" );
             }
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Release" );
+            add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages" );
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.gz" );
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.bz2" );
             add_url_to_download( $url . $_ . "/binary-" . $arch . "/Packages.xz" );
@@ -455,6 +456,7 @@ foreach (@config_binaries)
     {
         add_url_to_download( $uri . "/$distribution/Release" );
         add_url_to_download( $uri . "/$distribution/Release.gpg" );
+        add_url_to_download( $uri . "/$distribution/Packages" );
         add_url_to_download( $uri . "/$distribution/Packages.gz" );
         add_url_to_download( $uri . "/$distribution/Packages.bz2" );
         add_url_to_download( $uri . "/$distribution/Packages.xz" );


### PR DESCRIPTION
At least one (GerritForge) public repo does not serve compressed Packages files. This commit
adds the uncompressed Packages file to the list url to download so apt-mirror can mirror that repo.

This works for me, but I must admit that I do not know if this is something that should work or if this is a workaround for a broken repo.