### PR TITLE
Add --no-verbose option to apt-mirror

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -112,6 +112,7 @@ my %config_variables = (
     "run_postmirror"       => 1,
     "auth_no_challenge"    => 0,
     "no_check_certificate" => 0,
+    "no_verbose"           => 0,
     "unlink"               => 0,
     "postmirror_script"    => '$var_path/postmirror.sh',
     "use_proxy"            => 'off',
@@ -239,6 +240,7 @@ sub download_urls
 
     if ( get_variable("auth_no_challenge") == 1 )    { push( @args, "--auth-no-challenge" ); }
     if ( get_variable("no_check_certificate") == 1 ) { push( @args, "--no-check-certificate" ); }
+    if ( get_variable("no_verbose") == 1 )           { push( @args, "--no-verbose" ); }
     if ( get_variable("unlink") == 1 )               { push( @args, "--unlink" ); }
     if ( length( get_variable("use_proxy") ) && ( get_variable("use_proxy") eq 'yes' || get_variable("use_proxy") eq 'on' ) )
     {


### PR DESCRIPTION
Hi,

This is a minor modification to add the "--no-verbose" option to apt-mirror. That way the logs are not overwhelmed by thousands and thousands of dots...........

Cheers,
  Evili
