### PR TITLE
Enable downloading icons @2 files in dep11

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -666,7 +666,7 @@ sub find_dep11_files_in_release
                 if ( @parts == 3 )
                 {
                     my ( $sha1, $size, $filename ) = @parts;
-                    if ( $filename =~ m{^$component/dep11/(Components-${arch}\.yml|icons-[^./]+\.tar)\.(gz|bz2|xz)$} )
+                    if ( $filename =~ m{^$component/dep11/(Components-${arch}\.yml|icons-(.*)+\.tar)\.(gz|bz2|xz)$} )
                     {
                         add_url_to_download( $dist_uri . $filename, $size );
                     }


### PR DESCRIPTION
Ubuntu18.04 have dep11 icons filenames with an "@" symbol.
The regex "[^./]"  excluding also the @ symbol and ignores the files.

Changing it to "(.*)" will now work with icons-.*@2.tar.gz files.