### PR TITLE
flag to disable progress output

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -16,14 +16,34 @@ A small and efficient tool that lets you mirror a part of or
 the whole Debian GNU/Linux distribution or any other apt sources.
 
 Main features:
- * It uses a config similar to APT's F<sources.list>
- * It's fully pool compliant
- * It supports multithreaded downloading
- * It supports multiple architectures at the same time
- * It can automatically remove unneeded files
- * It works well on an overloaded Internet connection
- * It never produces an inconsistent mirror including while mirroring
- * It works on all POSIX compliant systems with Perl and wget
+
+=over
+
+=item *
+It uses a config similar to APT's F<sources.list>
+
+=item *
+It's fully pool compliant
+
+=item *
+It supports multithreaded downloading
+
+=item *
+It supports multiple architectures at the same time
+
+=item *
+It can automatically remove unneeded files
+
+=item *
+It works well on an overloaded Internet connection
+
+=item *
+It never produces an inconsistent mirror including while mirroring
+
+=item *
+It works on all POSIX compliant systems with Perl and wget
+
+=back
 
 =head1 COMMENTS
 

--- a/apt-mirror
+++ b/apt-mirror
@@ -8,7 +8,7 @@ apt-mirror - apt sources mirroring tool
 
 =head1 SYNOPSIS
 
-apt-mirror [configfile]
+apt-mirror [--[no-]progress] [--verbose] [configfile]
 
 =head1 DESCRIPTION
 
@@ -114,6 +114,7 @@ use File::Compare;
 use File::Path qw(make_path);
 use File::Basename;
 use Fcntl qw(:flock);
+use Getopt::Long;
 
 my $config_file;
 
@@ -160,10 +161,17 @@ my %hashsum_to_files = ();
 # Mapping of all the checksums for a given canonical filename.
 my %file_to_hashsums;
 
+my $verbose         = 0;
+my $progress        = 1;
+
 ######################################################################################
 ## Setting up $config_file variable
 
 $config_file = "/etc/apt/mirror.list";    # Default value
+GetOptions('verbose|v+', \$verbose,
+           'progress|p!', \$progress,
+    ) or die "Usage: apt-mirror [--verbose] [--[no-]progress] [configfile]\n";
+
 if ( $_ = shift )
 {
     die("apt-mirror: invalid config file specified") unless -e $_;
@@ -317,7 +325,9 @@ sub download_urls
         open URLS, ">" . get_variable("var_path") . "/$stage-urls.$i" or die("apt-mirror: can't write to intermediate file ($stage-urls.$i)");
         foreach (@part) { print URLS "$_\n"; }
         close URLS or die("apt-mirror: can't close intermediate file ($stage-urls.$i)");
-
+        if ($verbose >= 2) {
+            print join("\n  ", "Downloading batch $i:", @part), "\n";
+        }
         $pid = fork();
 
         die("apt-mirror: can't do fork in download_urls") if !defined($pid);
@@ -335,14 +345,17 @@ sub download_urls
         $nthreads--;
     }
 
-    print "Begin time: " . localtime() . "\n[" . scalar(@childrens) . "]... ";
+    print "Begin time: " . localtime() . "\n[" . scalar(@childrens) . "]... "
+        if $progress;
     while ( scalar @childrens )
     {
         my $dead = wait();
         @childrens = grep { $_ != $dead } @childrens;
-        print "[" . scalar(@childrens) . "]... ";
+        print "[" . scalar(@childrens) . "]... "
+            if $progress;
     }
-    print "\nEnd time: " . localtime() . "\n\n";
+    print "\nEnd time: " . localtime() . "\n\n"
+        if $progress;
 
     if (scalar keys %hashsum_to_files > 0)
     {
@@ -796,7 +809,9 @@ foreach (@config_sources)
         }
     }
 }
-print "]\n\n";
+
+print "]\n\n" if $progress;
+
 
 @index_urls = sort keys %urls_to_download;
 download_urls( "index", @index_urls );
@@ -899,12 +914,16 @@ sub process_index
         {    # Packages index
             $skipclean{ remove_double_slashes( $path . "/" . $lines{"Filename:"} ) } = 1;
             print FILES_ALL remove_double_slashes( $path . "/" . $lines{"Filename:"} ) . "\n";
+            print "ALL: " . remove_double_slashes( $path . "/" . $lines{"Filename:"} ) . "\n"
+                if $verbose >= 3;
             print FILES_MD5 $lines{"MD5sum:"} . "  " . remove_double_slashes( $path . "/" . $lines{"Filename:"} ) . "\n" if defined $lines{"MD5sum:"};
             print FILES_SHA1 $lines{"SHA1:"} . "  " . remove_double_slashes( $path . "/" . $lines{"Filename:"} ) . "\n" if defined $lines{"SHA1:"};
             print FILES_SHA256 $lines{"SHA256:"} . "  " . remove_double_slashes( $path . "/" . $lines{"Filename:"} ) . "\n" if defined $lines{"SHA256:"};
             if ( need_update( $mirror . "/" . $lines{"Filename:"}, $lines{"Size:"} ) )
             {
                 print FILES_NEW remove_double_slashes( $uri . "/" . $lines{"Filename:"} ) . "\n";
+                print "NEW: " . remove_double_slashes( $uri . "/" . $lines{"Filename:"} ) . "\n"
+                    if $verbose >= 1;
                 add_url_to_download( $uri . "/" . $lines{"Filename:"}, $lines{"Size:"} );
             }
         }
@@ -917,10 +936,14 @@ sub process_index
                 die("apt-mirror: invalid Sources format") if @file != 3;
                 $skipclean{ remove_double_slashes( $path . "/" . $lines{"Directory:"} . "/" . $file[2] ) } = 1;
                 print FILES_ALL remove_double_slashes( $path . "/" . $lines{"Directory:"} . "/" . $file[2] ) . "\n";
+                print "ALL: " . remove_double_slashes( $path . "/" . $lines{"Directory:"} . "/" . $file[2] ) . "\n"
+                    if $verbose >= 3;
                 print FILES_MD5 $file[0] . "  " . remove_double_slashes( $path . "/" . $lines{"Directory:"} . "/" . $file[2] ) . "\n";
                 if ( need_update( $mirror . "/" . $lines{"Directory:"} . "/" . $file[2], $file[1] ) )
                 {
                     print FILES_NEW remove_double_slashes( $uri . "/" . $lines{"Directory:"} . "/" . $file[2] ) . "\n";
+                    print "NEW: " . remove_double_slashes( $uri . "/" . $lines{"Directory:"} . "/" . $file[2] ) . "\n"
+                        if $verbose >= 1;
                     add_url_to_download( $uri . "/" . $lines{"Directory:"} . "/" . $file[2], $file[1] );
                 }
             }
@@ -930,12 +953,13 @@ sub process_index
     close STREAM;
 }
 
-print "Processing indexes: [";
+print "Processing indexes: ["
+    if $progress;
 
 foreach (@config_sources)
 {
     my ( $uri, $distribution, @components ) = @{$_};
-    print "S";
+    print "S" if $progress;
     if (@components)
     {
         my $component;
@@ -953,7 +977,7 @@ foreach (@config_sources)
 foreach (@config_binaries)
 {
     my ( $arch, $uri, $distribution, @components ) = @{$_};
-    print "P";
+    print "P" if $progress;
     if (@components)
     {
         my $component;
@@ -971,7 +995,8 @@ foreach (@config_binaries)
 
 clear_stat_cache();
 
-print "]\n\n";
+print "]\n\n"
+    if $progress;
 
 close FILES_ALL;
 close FILES_NEW;
@@ -1128,6 +1153,7 @@ else
     foreach (@rm_files)
     {
         print CLEAN "rm -f '$_'\n";
+        print "  $_\n" if $verbose >= 1;
         print CLEAN "echo -n '[" . int( 100 * $i / $total ) . "\%]'\n" unless $i % 500;
         print CLEAN "echo -n .\n" unless $i % 10;
         $i++;


### PR DESCRIPTION
when running from cron, the progress output is a distraction from the log files.  this patch adds an option to turn it off, and also an option to increase verbosity for debugging.
