### PR TITLE
use rm -r instead of rmdir when cleaning directories

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -1031,7 +1031,7 @@ else
     print CLEAN "echo 'Removing $total unnecessary directories...'\n";
     foreach (@rm_dirs)
     {
-        print CLEAN "if test -d '$_'; then rmdir '$_'; fi\n";
+        print CLEAN "if test -d '$_'; then rmdir -r'$_'; fi\n";
         print CLEAN "echo -n '[" . int( 100 * $i / $total ) . "\%]'\n" unless $i % 50;
         print CLEAN "echo -n .\n";
         $i++;

--- a/apt-mirror
+++ b/apt-mirror
@@ -1031,7 +1031,7 @@ else
     print CLEAN "echo 'Removing $total unnecessary directories...'\n";
     foreach (@rm_dirs)
     {
-        print CLEAN "if test -d '$_'; then rmdir -r'$_'; fi\n";
+        print CLEAN "if test -d '$_'; then rm -r'$_'; fi\n";
         print CLEAN "echo -n '[" . int( 100 * $i / $total ) . "\%]'\n" unless $i % 50;
         print CLEAN "echo -n .\n";
         $i++;


### PR DESCRIPTION
rmdir removes only empty directories, and errors out otherwise. rm -r removes both empty and nonempty