### PR TITLE
Add missing  support for xz translations missing

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -520,7 +520,7 @@ sub find_translation_files_in_release
                 if ( @parts == 3 )
                 {
                     my ( $sha1, $size, $filename ) = @parts;
-                    if ( $filename =~ m{^$component/i18n/Translation-[^./]*\.bz2$} )
+                    if ( $filename =~ m{^$component/i18n/Translation-[^./]*\.(bz2|xz)$} )
                     {
                         add_url_to_download( $dist_uri . $filename, $size );
                     }


### PR DESCRIPTION
Fix a bug which caused apt-mirror ignores Translation files
It's due to i18n/Tranlation-* files are compressed as xz in Debian Buster instead bz2 as in earlier releases.
https://github.com/apt-mirror/apt-mirror/issues/125