### PR TITLE
Added support for cnf directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,4 @@
 This is a fork of the original apt-mirror.
-The only addition is that this version now supports cnf (command-not-found) folder structures in the newer repos (such as eaon and focal).
-
-
-apt-mirror
 ==========
 
-See: http://apt-mirror.github.com
-
-New maintainer(s) wanted
-========================
-
-We (the current maintainers) lack the time and energy to maintain apt-mirror:
-Our last commit is years old and the number of pull request is rising. We
-agreed on acknowledging this fact and are searching for new maintainers who
-wants to join the GitHub apt-mirror group and continue maintaining this
-repository and do new releases. If you are interested and have time and energy
-to take the project over, please contact Brandon Holtsclaw to give you the
-permission.
+The only addition is that this version now supports cnf (command-not-found) folder structures in the newer repos (such as eaon and focal).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This is a fork of the original apt-mirror.
+The only addition is that this version now supports cnf (command-not-found) folder structures in the newer repos (such as eaon and focal).
+
+
 apt-mirror
 ==========
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ This is a fork of the original apt-mirror.
 ==========
 
 The only addition is that this version now supports cnf (command-not-found) folder structures in the newer repos (such as eaon and focal).
+
+See: https://github.com/Stifler6996/apt-mirror/pull/1 for the change.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a fork of the original apt-mirror.
 ==========
 
-The only addition is that this version now supports cnf (command-not-found) folder structures in the newer repos (such as eaon and focal).
+This version now supports cnf (command-not-found) folder structures in the newer repos (such as eaon and focal). https://github.com/Stifler6996/apt-mirror/commit/c6a8a7eacf48f72453f1d5920a1514761679c952
 
-See: https://github.com/Stifler6996/apt-mirror/pull/1 for the change.
+This version adds support for files with the "@" character in filenames. https://github.com/Stifler6996/apt-mirror/commit/36255f35e9a8698c46ce20d06412e8bc16f821fc

--- a/apt-mirror
+++ b/apt-mirror
@@ -485,7 +485,8 @@ sub sanitise_uri
 {
     my $uri = shift;
     $uri =~ s[^(\w+)://][];
-    $uri =~ s/^([^@]+)?@?// if $uri =~ /@/;
+    #$uri =~ s/^([^@]+)?@?// if $uri =~ /@/;
+    $uri =~ s/^([^@]+)?@?// if (split '/',$uri)[0] =~ /@/;
     $uri =~ s&:\d+/&/&;                       # and port information
     $uri =~ s/~/\%7E/g if get_variable("_tilde");
     return $uri;


### PR DESCRIPTION
This adds one additional line to the perl script that adds support for the cnf directories and the "Command-[arch].xz" files within.

This solves all problems with any distro that has command-not-found structure in its repo's. This includes Focal and Dingo.
