### PR TITLE
Update the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 apt-mirror
 ==========
 
-See: http://apt-mirror.github.com
+See: https://apt-mirror.github.io/
 
 New maintainer(s) wanted
 ========================


### PR DESCRIPTION
The link points to the following text:

> There isn't a GitHub Pages site here.
> 
> Did you mean to visit apt-mirror.github.io? Please note that this site belongs to a GitHub user and is not an official GitHub site.
> 
> If you're the owner of this site, please update your links to use apt-mirror.github.io instead. Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.