### PR TITLE
Support for xz translations

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -520,7 +520,7 @@ sub find_translation_files_in_release
                 if ( @parts == 3 )
                 {
                     my ( $sha1, $size, $filename ) = @parts;
-                    if ( $filename =~ m{^$component/i18n/Translation-[^./]*\.bz2$} )
+                    if ( $filename =~ m{^$component/i18n/Translation-[^./]*\.(bz2|xz)$} )
                     {
                         add_url_to_download( $dist_uri . $filename, $size );
                     }


### PR DESCRIPTION
- In the case of bullseye-security distributed by the debian security camp,
  the extension of Translation-en file of bullseye-security is xz format.
  (http://security.debian.org/debian-security/dists/bullseye-security/main/i18n/Translation-en.xz)

- Accordingly, the apt-mirror script was modified to support the xz extension.