### PR TITLE
Enable copying the @2 files from dep11

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -533,8 +533,8 @@ download_urls( "release", @release_urls );
 sub sanitise_uri
 {
     my $uri = shift;
-    $uri =~ s[^(\w+)://][];
-    $uri =~ s/^([^@]+)?@?// if $uri =~ /@/;
+    $uri =~ s[^(\w+)://][]; # Drop the protocol prefix (if any)
+    $uri =~ s[^([^/]+)@][]; # Drop the username and password (if any)
     $uri =~ s/~/\%7E/g if get_variable("_tilde");
     return $uri;
 }


### PR DESCRIPTION
If the repository does not declare Acquire-By-Hash, the @2 files do not get copied.

fixes 103

As pointed out in https://github.com/apt-mirror/apt-mirror/issues/102#issuecomment-1581997361 this issue still persists.